### PR TITLE
fix-logback-warning: moved immediateFlush attribute to enclosing appe…

### DIFF
--- a/src/main/g8/src/test/resources/logback.xml
+++ b/src/main/g8/src/test/resources/logback.xml
@@ -2,9 +2,9 @@
 <configuration>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>false</immediateFlush>
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%-5level] %logger{15} - %msg%n%rEx</pattern>
-            <immediateFlush>false</immediateFlush>
         </encoder>
     </appender>
 


### PR DESCRIPTION
…nder.

This fixes the warning:
`|-WARN in ch.qos.logback.classic.encoder.PatternLayoutEncoder@2d5eb996 - As of version 1.2.0 "immediateFlush" property should be set within the enclosing Appender.`