### PR TITLE
PLATUI-1162: Update performance-test-runner to use 5.0.0

### DIFF
--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
 
   val test = Seq(
     "com.typesafe"          % "config"                    % "1.3.1"         % Test,
-    "uk.gov.hmrc"          %% "performance-test-runner"   % "4.11.0"        % Test,
+    "uk.gov.hmrc"          %% "performance-test-runner"   % "5.0.0"        % Test,
     "io.gatling"            % "gatling-test-framework"    % gatlingVersion  % Test,
     "io.gatling.highcharts" % "gatling-charts-highcharts" % gatlingVersion  % Test
   )

--- a/src/main/g8/src/test/resources/application.conf
+++ b/src/main/g8/src/test/resources/application.conf
@@ -1,17 +1,9 @@
 # Copyright 2020 HM Revenue & Customs
 #
 
-# The default url for every service.
-# For example
-# ServicesConfiguration.baseUrlFor("helloworld-service") == https://helloworld-service.co.uk
-baseUrl = "https://www.staging.tax.service.gov.uk"
-
-
-# The baseUrl can be overridden in services-local.conf. See that file for more information
-# That file is ignored when the test is not run locally. The default is true
+# Configures the test to run locally. The default value is true.
+# When true, services-local.conf file is used. When false, services.conf is used
 #runLocal = false
-
-
 
 perftest {
 

--- a/src/main/g8/src/test/resources/services-local.conf
+++ b/src/main/g8/src/test/resources/services-local.conf
@@ -3,9 +3,6 @@
 
 # This file is read when runLocal = true in application.conf (default)
 
-# This can be used to override the 'baseUrl'
-
-# If the service name you are searching is found, baseUrl is overridden.
 # For local development convenience, host and protocol will have the following defaults:
 #      protocol = http
 #      host = localhost

--- a/src/main/g8/src/test/resources/services.conf
+++ b/src/main/g8/src/test/resources/services.conf
@@ -3,9 +3,6 @@
 
 # This file is read when runLocal = false in application.conf (default is false)
 
-# This can be used to override the 'baseUrl'
-
-# If the service name you are searching is found, baseUrl is overridden.
 # For local development convenience, host and protocol will have the following defaults:
 #      protocol = http
 #      port = 8080


### PR DESCRIPTION
- Remove references to `baseUrl` in application.conf. `baseUrl` is obsolete.